### PR TITLE
[FIX] mail: emails with empty attachment not sent

### DIFF
--- a/addons/mail/mail_mail.py
+++ b/addons/mail/mail_mail.py
@@ -251,7 +251,7 @@ class mail_mail(osv.Model):
                 # `datas` (binary field) could bloat the browse cache, triggerring
                 # soft/hard mem limits with temporary data.
                 attachment_ids = [a.id for a in mail.attachment_ids]
-                attachments = [(a['datas_fname'], base64.b64decode(a['datas']))
+                attachments = [(a['datas_fname'], base64.b64decode(a['datas'] or ''))
                                  for a in ir_attachment.read(cr, SUPERUSER_ID, attachment_ids,
                                                              ['datas_fname', 'datas'])]
 


### PR DESCRIPTION
**Emails with empty files in the attachment are not sent**

Impacted versions:

 - 8.0

Steps to reproduce:

 1. create a new email via the compose message dialog
 2. add an empty file as the attachment
 3. click on the "Send" button

Current behavior:

 - An exception is thrown and the email is not sent.

Expected behavior:

 - The email should be sent with that empty file as the attachment.